### PR TITLE
renamed keychain prefix

### DIFF
--- a/KinSDK/KinSDK/source/KeyStore.swift
+++ b/KinSDK/KinSDK/source/KeyStore.swift
@@ -247,7 +247,7 @@ extension KeyStore {
 }
 
 private struct KeychainStorage {
-    static let keychainPrefix = "__swifty_stellar_"
+    static let keychainPrefix = "KinSDK_"
     static let keychain = KeychainSwift(keyPrefix: keychainPrefix)
 
     static func nextStorageKey() -> String {


### PR DESCRIPTION
When the user upgrades from KinCore to KinSDK they will need to make a new account. This new account should have from the beginning a renamed keychain prefix. 

If someone, internally or externally, needs to debug the values in the keychain, it should be clear which are apart of the KinSDK.