### PR TITLE
Fixed network_id for production kin3

### DIFF
--- a/KinSDK.podspec
+++ b/KinSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'KinSDK'
-  s.version      = '0.8.4'
+  s.version      = '0.8.5'
   s.summary      = 'Pod for the KIN SDK.'
   s.description  = "Initial pod for the KIN SDK."
   s.homepage     = 'https://github.com/kinecosystem/kin-sdk-ios'

--- a/KinSDK/KinSDK/source/Network.swift
+++ b/KinSDK/KinSDK/source/Network.swift
@@ -49,7 +49,7 @@ extension Network {
     public var id: Id {
         switch self {
         case .mainNet:
-            return "Public Global Kin Ecosystem Network ; June 2018"
+            return "Kin Mainnet ; December 2018"
         case .testNet:
             return "Kin Testnet ; December 2018"
         case .playground:


### PR DESCRIPTION
Changed production network_id to "Kin Mainnet ; December 2018" from "Public Global Kin Ecosystem Network ; June 2018".  This will resolve issues to /order/{order_id}/whitelist endpoint.