### PR TITLE
Fix crashes caused by found nil while unwrapping an Optional value

### DIFF
--- a/KinSDK/KinSDK/source/KinAccount.swift
+++ b/KinSDK/KinSDK/source/KinAccount.swift
@@ -160,8 +160,8 @@ final class KinStellarAccount: KinAccount {
 
     var deleted = false
     
-    var publicAddress: String {
-        return stellarAccount.publicKey!
+    var publicAddress: String? {
+        return stellarAccount.publicKey
     }
 
     var extra: Data? {
@@ -313,7 +313,7 @@ final class KinStellarAccount: KinAccount {
     }
 
     func balance(completion: @escaping BalanceCompletion) {
-        guard deleted == false else {
+        guard deleted == false && stellarAccount.publicKey != nil else {
             completion(nil, KinError.accountDeleted)
             
             return
@@ -333,7 +333,7 @@ final class KinStellarAccount: KinAccount {
     }
     
     public func watchBalance(_ balance: Kin?) throws -> BalanceWatch {
-        guard deleted == false else {
+        guard deleted == false && stellarAccount.publicKey != nil else {
             throw KinError.accountDeleted
         }
 
@@ -341,7 +341,7 @@ final class KinStellarAccount: KinAccount {
     }
 
     public func watchPayments(cursor: String?) throws -> PaymentWatch {
-        guard deleted == false else {
+        guard deleted == false && stellarAccount.publicKey != nil else {
             throw KinError.accountDeleted
         }
 
@@ -349,7 +349,7 @@ final class KinStellarAccount: KinAccount {
     }
 
     public func watchCreation() throws -> Promise<Void> {
-        guard deleted == false else {
+        guard deleted == false && stellarAccount.publicKey != nil else {
             throw KinError.accountDeleted
         }
 

--- a/KinSDK/KinSDK/source/KinAccount.swift
+++ b/KinSDK/KinSDK/source/KinAccount.swift
@@ -18,7 +18,7 @@ public protocol KinAccount: class {
      The public address of this account. If the user wants to receive KIN by sending his address
      manually to someone, or if you want to display the public address, use this property.
      */
-    var publicAddress: String { get }
+    var publicAddress: String? { get }
 
     var extra: Data? { get set }
 

--- a/KinSDK/KinSDK/source/blockchain/StellarEventSource.swift
+++ b/KinSDK/KinSDK/source/blockchain/StellarEventSource.swift
@@ -237,7 +237,7 @@ public final class StellarEventSource: NSObject, URLSessionDataDelegate {
             }
         }
         else {
-            emitter.finish()
+            emitter?.finish()
         }
     }
 }


### PR DESCRIPTION
We found several crashes in KinAccount.swift. The crashes happened when force unwrapping publicKey. The force unwrapping will throw fatal error and we cannot use try-catch to handle it.

We are using kin-ecosystem-ios-sdk 0.8.0 and kin-core-sdk 0.7.17

Here are the crashes logs:
 
[com.quoord.tapatalk_issue_crash_3a148dbb8f1841ffb2e78b05393060a5_DNE_0_v2.txt](https://github.com/kinecosystem/kin-sdk-ios/files/3007465/com.quoord.tapatalk_issue_crash_3a148dbb8f1841ffb2e78b05393060a5_DNE_0_v2.txt)
[com.quoord.tapatalk_issue_crash_14e07512657049c5bbfa6672d47ff44b_DNE_0_v2.txt](https://github.com/kinecosystem/kin-sdk-ios/files/3007466/com.quoord.tapatalk_issue_crash_14e07512657049c5bbfa6672d47ff44b_DNE_0_v2.txt)
[com.quoord.tapatalk_issue_crash_bc3d3b832d2f40a5b833898f06f671a4_DNE_0_v2.txt](https://github.com/kinecosystem/kin-sdk-ios/files/3007467/com.quoord.tapatalk_issue_crash_bc3d3b832d2f40a5b833898f06f671a4_DNE_0_v2.txt)


