### PR TITLE
DP-632 - integ tests on internal test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
     fi
   - |
     if [ $TEST_MATRIX == "test" ]; then
+      # inject integration environment params for testing from env variable by string replacing content of a template file  
+      sed -e  "s@INTEG_TESTS_NETWORK_URL@$INTEG_TESTS_NETWORK_URL@" -e "s@INTEG_TESTS_NETWORK_PASSPHRASE@$INTEG_TESTS_NETWORK_PASSPHRASE@" -e "s@INTEG_TESTS_NETWORK_FRIENDBOT@$INTEG_TESTS_NETWORK_FRIENDBOT@" scripts/IntegEnvironmentTemplate.swift > KinSDKTests/IntegEnvironment.swift
       xcodebuild test -workspace KinSDK.xcworkspace -scheme KinSDKTestsHost -destination 'platform=iOS Simulator,name=iPhone X'
     fi
 

--- a/KinSDK.xcodeproj/project.pbxproj
+++ b/KinSDK.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		68AF931222A92DCF008C01EC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AF931122A92DCF008C01EC /* ViewController.swift */; };
 		68AF931722A92DD1008C01EC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68AF931622A92DD1008C01EC /* Assets.xcassets */; };
 		68AF931A22A92DD1008C01EC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 68AF931822A92DD1008C01EC /* LaunchScreen.storyboard */; };
+		C2B037F122F76259001F98B8 /* IntegEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B037F022F76259001F98B8 /* IntegEnvironment.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -220,6 +221,7 @@
 		68AF931622A92DD1008C01EC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		68AF931922A92DD1008C01EC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		68AF931B22A92DD1008C01EC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C2B037F022F76259001F98B8 /* IntegEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegEnvironment.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -425,6 +427,7 @@
 				68319EB222DC62CF00EC2DDF /* URLKinVersion.swift */,
 				68319EAF22DC62CE00EC2DDF /* XDRTests.swift */,
 				68AF917322A90C6A008C01EC /* Info.plist */,
+				C2B037F022F76259001F98B8 /* IntegEnvironment.swift */,
 			);
 			path = KinSDKTests;
 			sourceTree = "<group>";
@@ -732,6 +735,7 @@
 				68319EB322DC62CF00EC2DDF /* KeyStoreTests.swift in Sources */,
 				68319EB822DC62CF00EC2DDF /* URLKinVersion.swift in Sources */,
 				68319EB522DC62CF00EC2DDF /* XDRTests.swift in Sources */,
+				C2B037F122F76259001F98B8 /* IntegEnvironment.swift in Sources */,
 				68319EB722DC62CF00EC2DDF /* AppIdTests.swift in Sources */,
 				68319EB622DC62CF00EC2DDF /* KinClientTests.swift in Sources */,
 			);

--- a/KinSDKTests/IntegEnvironment.swift
+++ b/KinSDKTests/IntegEnvironment.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct IntegEnvironment {
+    static let networkUrl: String = "https://horizon-testnet.kininfrastructure.com"
+    static let networkPassphrase: String = "Kin Testnet ; December 2018"
+    static let friendbotUrl: String = "https://friendbot-testnet.kininfrastructure.com"
+}

--- a/KinSDKTests/IntegEnvironment.swift
+++ b/KinSDKTests/IntegEnvironment.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// NOTE: This params are changed in CI by injecting them from environemnt variables, any change should be reflected as well in CI
+// and in the template file scripts/IntegEnvironmentTemplate.swift
 public struct IntegEnvironment {
     static let networkUrl: String = "https://horizon-testnet.kininfrastructure.com"
     static let networkPassphrase: String = "Kin Testnet ; December 2018"

--- a/KinSDKTests/KinAccountTests.swift
+++ b/KinSDKTests/KinAccountTests.swift
@@ -345,7 +345,7 @@ extension KinAccountTests {
         let group = DispatchGroup()
         group.enter()
 
-        let url = URL(string: "\(IntegEnvironment.friendbotUrl)?addr=\(kinAccount.publicAddress)&amount\(amount)")!
+        let url = URL(string: "\(IntegEnvironment.friendbotUrl)?addr=\(kinAccount.publicAddress)&amount=\(amount)")!
         URLSession.shared.dataTask(with: url, completionHandler: { data, response, error in
             guard
                 let data = data,

--- a/KinSDKTests/KinAccountTests.swift
+++ b/KinSDKTests/KinAccountTests.swift
@@ -18,15 +18,13 @@ class KinAccountTests: XCTestCase {
     var account1: KinAccount!
     var issuer: StellarAccount?
 
-    let endpoint = "https://horizon-testnet.kininfrastructure.com"
-    let sNetwork: Network = .testNet
-    lazy var kNetwork: Network = .testNet
+    let endpoint = IntegEnvironment.networkUrl
+    lazy var kNetwork: Network = .custom(IntegEnvironment.networkPassphrase)
 
     let requestTimeout: TimeInterval = 30
 
     override func setUp() {
         super.setUp()
-
         continueAfterFailure = false
 
         guard let appId = try? AppId("test") else {
@@ -347,7 +345,7 @@ extension KinAccountTests {
         let group = DispatchGroup()
         group.enter()
 
-        let url = URL(string: "https://friendbot-testnet.kininfrastructure.com?addr=\(kinAccount.publicAddress)&amount\(amount)")!
+        let url = URL(string: "\(IntegEnvironment.friendbotUrl)?addr=\(kinAccount.publicAddress)&amount\(amount)")!
         URLSession.shared.dataTask(with: url, completionHandler: { data, response, error in
             guard
                 let data = data,

--- a/scripts/IntegEnvironmentTemplate.swift
+++ b/scripts/IntegEnvironmentTemplate.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct IntegEnvironment {
+    static let networkUrl: String = "INTEG_TESTS_NETWORK_URL"
+    static let networkPassphrase: String = "INTEG_TESTS_NETWORK_PASSPHRASE"
+    static let friendbotUrl: String = "INTEG_TESTS_NETWORK_FRIENDBOT"
+}


### PR DESCRIPTION
### Purpose
Add the ability to change integration network environment in CI level by defining environment variables. 
The idea is to use a dedicated internal testnet network for CI testing.
The default network for dev environment will remain the public testnet

### Technical Details:
Added a new `IntegEnvironment.swift` file to tests, this file will be overridden in CI, by taking the template file `scripts/IntegEnvironmentTemplate.swift` and string replacing the params from an environment variables outputting it to `IntegEnvironment.swift` before running tests.